### PR TITLE
[B1M2-1167] Allow setting tracer at runtime

### DIFF
--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -14,7 +14,7 @@ defmodule SpandexEcto.EctoLogger do
   def trace(log_entry, database) do
     # Put in your own configuration here
     config = Application.get_env(:spandex_ecto, __MODULE__)
-    tracer = config[:tracer] || raise "tracer is a required option for #{inspect(__MODULE__)}"
+    tracer = config[:tracer]
     service = config[:service] || :ecto
     truncate = config[:truncate] || 5000
 

--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -11,11 +11,10 @@ defmodule SpandexEcto.EctoLogger do
 
   @empty_query_placeholder "unknown (unsupported ecto adapter?)"
 
-  def trace(log_entry, database) do
+  def trace(log_entry, database, service) do
     # Put in your own configuration here
     config = Application.get_env(:spandex_ecto, __MODULE__)
     tracer = config[:tracer]
-    service = config[:service] || :ecto
     truncate = config[:truncate] || 5000
 
     if tracer.current_trace_id() do

--- a/lib/spandex_ecto/telemetry_adapter.ex
+++ b/lib/spandex_ecto/telemetry_adapter.ex
@@ -6,12 +6,12 @@ defmodule SpandexEcto.TelemetryAdapter do
   alias SpandexEcto.EctoLogger
 
   #  this is for ecto_sql 3.0.x
-  def handle_event([app_name, repo_name, :query], total_time, log_entry, _config) when is_integer(total_time) do
-    EctoLogger.trace(log_entry, "#{repo_name}_database", String.to_atom("#{app_name}_#{repo_name}"))
+  def handle_event([app_name, repo_name, :query], total_time, log_entry, config) when is_integer(total_time) do
+    EctoLogger.trace(log_entry, "#{repo_name}_database", service(config, app_name, repo_name))
   end
 
   # This is for ecto_sql >= 3.1
-  def handle_event([app_name, repo_name, :query], measurements, metadata, _config) when is_map(measurements) do
+  def handle_event([app_name, repo_name, :query], measurements, metadata, config) when is_map(measurements) do
     log_entry = %{
       query: metadata.query,
       source: metadata.source,
@@ -22,7 +22,7 @@ defmodule SpandexEcto.TelemetryAdapter do
       result: wrap_result(metadata.result)
     }
 
-    EctoLogger.trace(log_entry, "#{repo_name}_database", String.to_atom("#{app_name}_#{repo_name}"))
+    EctoLogger.trace(log_entry, "#{repo_name}_database", service(config, app_name, repo_name))
   end
 
   def handle_event(event_name, measurements, log_entry, config) when is_list(event_name) do
@@ -33,4 +33,8 @@ defmodule SpandexEcto.TelemetryAdapter do
 
   defp wrap_result(result) when is_atom(result), do: {result, "n/a"}
   defp wrap_result(result), do: result
+
+  defp service(config, app_name, repo_name) do
+    config[:service] || String.to_atom("#{app_name}_#{repo_name}")
+  end
 end

--- a/lib/spandex_ecto/telemetry_adapter.ex
+++ b/lib/spandex_ecto/telemetry_adapter.ex
@@ -6,12 +6,12 @@ defmodule SpandexEcto.TelemetryAdapter do
   alias SpandexEcto.EctoLogger
 
   #  this is for ecto_sql 3.0.x
-  def handle_event([_app_name, repo_name, :query], total_time, log_entry, _config) when is_integer(total_time) do
-    EctoLogger.trace(log_entry, "#{repo_name}_database")
+  def handle_event([app_name, repo_name, :query], total_time, log_entry, _config) when is_integer(total_time) do
+    EctoLogger.trace(log_entry, "#{repo_name}_database", String.to_atom("#{app_name}_#{repo_name}"))
   end
 
   # This is for ecto_sql >= 3.1
-  def handle_event([_app_name, repo_name, :query], measurements, metadata, _config) when is_map(measurements) do
+  def handle_event([app_name, repo_name, :query], measurements, metadata, _config) when is_map(measurements) do
     log_entry = %{
       query: metadata.query,
       source: metadata.source,
@@ -22,7 +22,7 @@ defmodule SpandexEcto.TelemetryAdapter do
       result: wrap_result(metadata.result)
     }
 
-    EctoLogger.trace(log_entry, "#{repo_name}_database")
+    EctoLogger.trace(log_entry, "#{repo_name}_database", String.to_atom("#{app_name}_#{repo_name}"))
   end
 
   def handle_event(event_name, measurements, log_entry, config) when is_list(event_name) do


### PR DESCRIPTION
Allow setting tracer at runtime for spandex_ecto. Removes raising error if tracer config is not set.

