### PR TITLE
Fix tracing execution of parallel preloads in Ecto

### DIFF
--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -117,9 +117,6 @@ defmodule SpandexEcto.EctoLogger do
       {_, trace} = List.keyfind(Process.info(caller_pid)[:dictionary], {:spandex_trace, tracer}, 0)
 
       case trace do
-        nil ->
-          tracer.start_span("query")
-
         %Trace{id: trace_id, stack: [%Span{id: span_id} | _]} ->
           tracer.continue_trace("query", %SpanContext{trace_id: trace_id, parent_id: span_id})
       end

--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -118,7 +118,7 @@ defmodule SpandexEcto.EctoLogger do
 
       case dictionary_map[{:spandex_trace, tracer}] do
         nil ->
-          tracer.start_trace("query")
+          tracer.start_span("query")
 
         %Trace{id: trace_id, stack: [%Span{id: span_id} | _]} ->
           tracer.continue_trace("query", %SpanContext{trace_id: trace_id, parent_id: span_id})

--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -5,6 +5,12 @@ defmodule SpandexEcto.EctoLogger do
   query is being run asynchronously (as in the case of parallel preloads).
   """
 
+  alias Spandex.{
+    Span,
+    SpanContext,
+    Trace
+  }
+
   defmodule Error do
     defexception [:message]
   end
@@ -18,75 +24,107 @@ defmodule SpandexEcto.EctoLogger do
     service = config[:service] || :ecto
     truncate = config[:truncate] || 5000
 
-    if tracer.current_trace_id() do
-      now = :os.system_time(:nano_seconds)
+    caller_pid =
+      case Process.get(:"$callers") do
+        [caller_process | _] ->
+          caller_process
 
-      query =
-        log_entry
-        |> string_query()
-        |> String.slice(0, truncate)
+        _ ->
+          self()
+      end
 
-      num_rows = num_rows(log_entry)
+    now = :os.system_time(:nano_seconds)
+    setup(caller_pid, tracer)
 
-      queue_time = get_time(log_entry, :queue_time)
-      query_time = get_time(log_entry, :query_time)
-      decoding_time = get_time(log_entry, :decode_time)
+    query =
+      log_entry
+      |> string_query()
+      |> String.slice(0, truncate)
 
-      start = now - (queue_time + query_time + decoding_time)
+    num_rows = num_rows(log_entry)
 
-      tracer.start_span(
-        "query",
-        start: start,
-        completion_time: now,
+    queue_time = get_time(log_entry, :queue_time)
+    query_time = get_time(log_entry, :query_time)
+    decoding_time = get_time(log_entry, :decode_time)
+
+    start = now - (queue_time + query_time + decoding_time)
+
+    tracer.update_span(
+      start: start,
+      completion_time: now,
+      service: service,
+      resource: query,
+      type: :db,
+      sql_query: [
+        query: query,
+        rows: inspect(num_rows),
+        db: database
+      ],
+      tags: tags(log_entry)
+    )
+
+    report_error(tracer, log_entry)
+
+    if queue_time != 0 do
+      tracer.start_span("queue")
+      tracer.update_span(service: service, start: start, completion_time: start + queue_time)
+      tracer.finish_span()
+    end
+
+    if query_time != 0 do
+      tracer.start_span("run_query")
+
+      tracer.update_span(
         service: service,
-        resource: query,
-        type: :db,
-        sql_query: [
-          query: query,
-          rows: inspect(num_rows),
-          db: database
-        ],
-        tags: tags(log_entry)
+        start: start + queue_time,
+        completion_time: start + queue_time + query_time
       )
-
-      Logger.metadata(trace_id: tracer.current_trace_id(), span_id: tracer.current_span_id())
-
-      report_error(tracer, log_entry)
-
-      if queue_time != 0 do
-        tracer.start_span("queue")
-        tracer.update_span(service: service, start: start, completion_time: start + queue_time)
-        tracer.finish_span()
-      end
-
-      if query_time != 0 do
-        tracer.start_span("run_query")
-
-        tracer.update_span(
-          service: service,
-          start: start + queue_time,
-          completion_time: start + queue_time + query_time
-        )
-
-        tracer.finish_span()
-      end
-
-      if decoding_time != 0 do
-        tracer.start_span("decode")
-
-        tracer.update_span(
-          service: service,
-          start: start + queue_time + query_time,
-          completion_time: now
-        )
-
-        tracer.finish_span()
-      end
 
       tracer.finish_span()
     end
 
+    if decoding_time != 0 do
+      tracer.start_span("decode")
+
+      tracer.update_span(
+        service: service,
+        start: start + queue_time + query_time,
+        completion_time: now
+      )
+
+      tracer.finish_span()
+    end
+
+    finish_ecto_trace(caller_pid, tracer)
+
     log_entry
+  end
+
+  defp finish_ecto_trace(caller_pid, tracer) do
+    if caller_pid != self() do
+      tracer.finish_trace()
+    else
+      tracer.finish_span()
+    end
+  end
+
+  defp setup(caller_pid, tracer) when is_pid(caller_pid) do
+    if caller_pid == self() do
+      tracer.start_span("query")
+    else
+      case Process.info(caller_pid, :dictionary)[:spandex_trace] do
+        nil ->
+          tracer.start_trace("query")
+
+        %Trace{id: trace_id, stack: [%Span{id: span_id} | _]} ->
+          tracer.continue_trace("query", %SpanContext{trace_id: trace_id, parent_id: span_id})
+
+        %Trace{id: trace_id, stack: []} ->
+          tracer.continue_trace("query", %SpanContext{trace_id: trace_id})
+      end
+    end
+
+    Logger.metadata(trace_id: tracer.current_trace_id(), span_id: tracer.current_span_id())
   end
 
   defp report_error(_tracer, %{result: {:ok, _}}), do: :ok

--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -112,7 +112,7 @@ defmodule SpandexEcto.EctoLogger do
     if caller_pid == self() do
       tracer.start_span("query")
     else
-      case Process.info(caller_pid, :dictionary)[:spandex_trace] do
+      case Process.info(caller_pid)[:dictionary][:spandex_trace] do
         nil ->
           tracer.start_trace("query")
 

--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -110,9 +110,13 @@ defmodule SpandexEcto.EctoLogger do
 
   defp setup(caller_pid, tracer) when is_pid(caller_pid) do
     if caller_pid == self() do
-      tracer.start_span("query")
+      if tracer.current_trace_id() do
+        tracer.start_span("query")
+      end
     else
-      case Process.info(caller_pid)[:dictionary][:spandex_trace] do
+      dictionary_map = Process.info(caller_pid)[:dictionary] |> Enum.into(%{})
+
+      case dictionary_map[{:spandex_trace, tracer}] do
         nil ->
           tracer.start_trace("query")
 

--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -101,10 +101,12 @@ defmodule SpandexEcto.EctoLogger do
   end
 
   defp finish_ecto_trace(caller_pid, tracer) do
-    if caller_pid != self() do
-      tracer.finish_trace()
-    else
-      tracer.finish_span()
+    if tracer.current_trace_id() do
+      if caller_pid != self() do
+        tracer.finish_trace()
+      else
+        tracer.finish_span()
+      end
     end
   end
 

--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -122,9 +122,6 @@ defmodule SpandexEcto.EctoLogger do
 
         %Trace{id: trace_id, stack: [%Span{id: span_id} | _]} ->
           tracer.continue_trace("query", %SpanContext{trace_id: trace_id, parent_id: span_id})
-
-        %Trace{id: trace_id, stack: []} ->
-          tracer.continue_trace("query", %SpanContext{trace_id: trace_id})
       end
     end
 

--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -114,9 +114,9 @@ defmodule SpandexEcto.EctoLogger do
         tracer.start_span("query")
       end
     else
-      dictionary_map = Process.info(caller_pid)[:dictionary] |> Enum.into(%{})
+      {_, trace} = List.keyfind(Process.info(caller_pid)[:dictionary], {:spandex_trace, tracer}, 0)
 
-      case dictionary_map[{:spandex_trace, tracer}] do
+      case trace do
         nil ->
           tracer.start_span("query")
 


### PR DESCRIPTION
This PR is based on conversations in following PR and a git commit

https://github.com/elixir-ecto/ecto/issues/2843
https://github.com/spandex-project/spandex_ecto/commit/a321d5f435fb2fb72c3ebde1b17104e2e611c9f1#diff-424a006e2a1dac6f34a878614aa2b57b7bd46e86221b5f0e07327c22dc135381

In `NewPhoenixBackendWeb.UserController` I have this function

```elixir
  def index(conn, _params) do
    users = Accounts.list_users()

    users = users |> Repo.preload([[posts: :comments], :pins, :mobile_phones], in_parallel: true)

    render(conn, "index.json", users: users)
  end
```


This is with fix in the PR is applied. 

![image](https://user-images.githubusercontent.com/266/120150403-a5ac6e00-c208-11eb-82ca-9e90babdd826.png)



This is without the fix in the PR applied.

![image](https://user-images.githubusercontent.com/266/120150446-b0ff9980-c208-11eb-80cc-55b587e7d02f.png)



As per Ecto source, Ecto does parallel preloads when there is 2 or more tables to preload
https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/repo/preloader.ex#L124



### Context

In this ecto commit Ecto removed adding caller_id to log_entry https://github.com/elixir-ecto/ecto/commit/8d09248c357d98e4096af449f6d0c20bc415fb92#diff-152ab0727a1d450c0fe74d178e80d1f0

that broke Spandex ecto functionality as issue created here by Spandex ecto author https://github.com/elixir-ecto/ecto/issues/2843

Later Elixir had added this $callers feature https://github.com/elixir-lang/elixir/pull/8510

Discussions about the issue
https://github.com/spandex-project/spandex_ecto/issues/12
https://github.com/spandex-project/spandex_ecto/pull/16
In above PR, author of Spandex Ecto mentions
```
I agree. This isn't really conventional, and it's possible, as far as I know, for the parent process to be dead while this log entry is happening, or for the parent span process to not be the most recent caller (think parallel preloads). I'd rather see an implementation that uses a registry of some kind, either in spandex core or in here.
```
